### PR TITLE
chore: weekly update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.8.20"
+    kotlin("jvm") version "1.8.21"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     application
 }


### PR DESCRIPTION
- Bumps kotlin-jvm from 1.8.20 to 1.8.21