### PR TITLE
chore: weekly update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.14-2 as builder
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.15-1 as builder
 
 # Installs gradle dependencies
 RUN mkdir app
@@ -15,7 +15,7 @@ RUN ./gradlew dependencies
 COPY --chown=default . .
 RUN ./gradlew shadowJar
 
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.14-2
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1
 
 ENV HEADLESS=TRUE
 ARG packages="chromium chromedriver"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.8.21"
+    kotlin("jvm") version "1.8.22"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     application
 }
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation("org.seleniumhq.selenium:selenium-java:4.9.1")
+    implementation("org.seleniumhq.selenium:selenium-java:4.10.0")
     implementation("com.github.ajalt.clikt:clikt:3.5.2")
     testImplementation(kotlin("test"))
 }


### PR DESCRIPTION
- Bumps selenium-java from 4.9.1 to 4.10.0
- Bumps kotlin-jvm from 1.8.21 to 1.8.22
- Bumps ubi9/openjdk-17 1.14-2 to 1.15.1
- Bumps ubi9/openjdk-17-runtime 1.14-2 to 1.15-1