### PR TITLE
chore: weekly update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/openjdk-17:1.15-1.1686736679 as builder
+FROM registry.access.redhat.com/ubi9/openjdk-17:1.15-2 as builder
 
 # Installs gradle dependencies
 RUN mkdir app
@@ -15,7 +15,7 @@ RUN ./gradlew dependencies
 COPY --chown=default . .
 RUN ./gradlew shadowJar
 
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-1.1686736681
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.15-2
 
 ENV HEADLESS=TRUE
 ARG packages="chromium chromedriver"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     implementation("org.seleniumhq.selenium:selenium-java:4.10.0")
-    implementation("com.github.ajalt.clikt:clikt:4.1.0")
+    implementation("com.github.ajalt.clikt:clikt:4.2.0")
     testImplementation(kotlin("test"))
 }
 


### PR DESCRIPTION
- bumps clikt from 4.1.0 to 4.2.0
- bumps ubi9/openjdk-17 from 1.15-1.1686736679 to 1.15-2
- bumps ubi9/openjdk-17-runtime from 1.15-1.1686736681 to 1.15-2